### PR TITLE
Tell curl to follow redirects

### DIFF
--- a/clean-rpm-gpg-pubkey
+++ b/clean-rpm-gpg-pubkey
@@ -119,6 +119,7 @@ foreach my $file (sort keys %gpgkeys)
 	"$dir/tmpimportkey.gpg",
 	"--silent",
 	"--show-error",
+        "--location",
 	$file) == 0 or die "Could not execute curl\n";
 
     system($gpg, "--homedir",


### PR DESCRIPTION
Fix an issue where the script dies if an https key returns a redirect.
E.g.

    gpg: no valid OpenPGP data found.
    Could not import https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key at /usr/bin/clean-rpm-gpg-pubkey line 87.
