### PR TITLE
Fix reading `fedora-release-common` version

### DIFF
--- a/clean-rpm-gpg-pubkey
+++ b/clean-rpm-gpg-pubkey
@@ -30,13 +30,12 @@ open($releasever, "-|",
      "rpm",
      "-q",
      '--queryformat=%{VERSION}\n',
+     "--whatprovides",
      "fedora-release-common");
 
 my $version = <$releasever>;
-close($releasever);
-
-die "Cannot read fedora-release-common version\n"
-    unless defined $version;
+close($releasever)
+    or die "Cannot read fedora-release-common version\n";
 chomp $version;
 
 my $arch = [ POSIX::uname ]->[4];


### PR DESCRIPTION
`fedora-release-common` package is not always installed, so use `--whatprovides` to handle the case where another package provides `fedora-release-common`.

`rpm -q fedora-release-common` would never return an empty output, even when the package is not installed. It prints the error:

> package fedora-release-common is not installed

and exits with non-zero status.