### PR TITLE
Tweak formatting of `Removing…` message

### DIFF
--- a/clean-rpm-gpg-pubkey
+++ b/clean-rpm-gpg-pubkey
@@ -189,7 +189,7 @@ foreach my $p (@packages)
 
     if ($n_now_keys != $n_keys)
     {
-	print (($dry_run ? "Would've removed: ":"Removing: ") . " "
+	print(($dry_run ? "Would've removed" : "Removing") . " "
 	    . $descr{$p} . "\n");
 
 	++$removed_counter;


### PR DESCRIPTION
Fixes the following warning:

```
print (...) interpreted as function at clean-rpm-gpg-pubkey line 192.
```